### PR TITLE
Update domain.py

### DIFF
--- a/bloodhound/ad/domain.py
+++ b/bloodhound/ad/domain.py
@@ -232,6 +232,9 @@ class ADDC(ADComputer):
 
         entriesNum = 0
         for entry in entries:
+            # Ensure systemFlags entry is not empty before running the naming context check.
+            if not entry['attributes']['systemFlags']:
+                continue
             # This is a naming context, but not a domain
             if not entry['attributes']['systemFlags'] & 2:
                 continue


### PR DESCRIPTION
Having an empty 'systemFlags' value will cause script to fail so, run a check to ensure that the value of entry['attributes']['systemFlags'] is not empty prior to running the check to determine if the value is that of a naming context. 