### PR TITLE
fixes ms-mcs-admpwd check in acls.py when there is no LAPS attributes in the environment.

### DIFF
--- a/bloodhound/enumeration/acls.py
+++ b/bloodhound/enumeration/acls.py
@@ -102,9 +102,9 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
                     # Report this as LAPS rights if it's a computer object AND laps is enabled
                     if entrytype == 'computer' and \
                     ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT) and \
-                    ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd'] and \
                     entry['Properties']['haslaps']:
-                        relations.append(build_relation(sid, 'ReadLAPSPassword', inherited=is_inherited))
+                        if ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd']:
+                            relations.append(build_relation(sid, 'ReadLAPSPassword', inherited=is_inherited))
                     else:
                         relations.append(build_relation(sid, 'GenericAll', inherited=is_inherited))
                     continue
@@ -135,9 +135,9 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
             if ace_object.acedata.mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_READ_PROP):
                 if entrytype == 'computer' and \
                 ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT) and \
-                ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd'] and \
                 entry['Properties']['haslaps']:
-                    relations.append(build_relation(sid, 'ReadLAPSPassword', inherited=is_inherited))
+                    if ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd']:
+                        relations.append(build_relation(sid, 'ReadLAPSPassword', inherited=is_inherited))
 
             # Extended rights
             control_access = ace_object.acedata.mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_CONTROL_ACCESS)


### PR DESCRIPTION
```
bloodhound-python -u USER -p PASS -dc lab-dc01.lab.justin-p.me -gc lab-dc01.lab.justin-p.me -d lab.justin-p.me -ns 10.11.12.1 -c all

...

INFO: Querying computer: LAB-DC01.lab.justin-p.me
ERROR: Unhandled exception in computer LAB-DC01.lab.justin-p.me processing: 'ms-mcs-admpwd'
INFO: Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/enumeration/computers.py", line 235, in process_computer
    results_q.put(('computer', c.get_bloodhound_data(entry, self.collect)))
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/ad/computer.py", line 151, in get_bloodhound_data
    self.addc.objecttype_guid_map)
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/enumeration/acls.py", line 138, in parse_binary_acl
    ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd'] and \
KeyError: 'ms-mcs-admpwd'

WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1131
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1132
ERROR: Unhandled exception in computer LAB-PC02.lab.justin-p.me processing: 'ms-mcs-admpwd'
INFO: Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/enumeration/computers.py", line 247, in process_computer
    results_q.put(('computer', c.get_bloodhound_data(entry, self.collect)))
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/ad/computer.py", line 151, in get_bloodhound_data
    self.addc.objecttype_guid_map)
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/enumeration/acls.py", line 138, in parse_binary_acl
    ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd'] and \
KeyError: 'ms-mcs-admpwd'

WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1133
ERROR: Unhandled exception in computer LAB-PC01.lab.justin-p.me processing: 'ms-mcs-admpwd'
INFO: Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/enumeration/computers.py", line 247, in process_computer
    results_q.put(('computer', c.get_bloodhound_data(entry, self.collect)))
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/ad/computer.py", line 151, in get_bloodhound_data
    self.addc.objecttype_guid_map)
  File "/usr/local/lib/python3.7/dist-packages/bloodhound-1.0.0-py3.7.egg/bloodhound/enumeration/acls.py", line 138, in parse_binary_acl
    ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd'] and \
KeyError: 'ms-mcs-admpwd'
```

Fixed the issue by creating an additional if-statement and checking for `ms-mcs-admpwd` after verifying if `haslaps` equals `True`.

```python
# Report this as LAPS rights if it's a computer object AND laps is enabled
if entrytype == 'computer' and \
ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT) and \
entry['Properties']['haslaps']:
    if ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd']:
        relations.append(build_relation(sid, 'ReadLAPSPassword', inherited=is_inherited))
else:
    relations.append(build_relation(sid, 'GenericAll', inherited=is_inherited))

...

# Property read privileges
if ace_object.acedata.mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_READ_PROP):
    if entrytype == 'computer' and \
    ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT) and \
    entry['Properties']['haslaps']:
        if ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-mcs-admpwd']:
            relations.append(build_relation(sid, 'ReadLAPSPassword', inherited=is_inherited))
```

```bash
bloodhound-python -u USER -p PASSWORD -dc lab-dc01.lab.justin-p.me -gc lab-dc01.lab.justin-p.me -d lab.justin-p.me -ns 10.11.12.1 -c all
INFO: Found AD domain: lab.justin-p.me
INFO: Connecting to LDAP server: lab-dc01.lab.justin-p.me
INFO: Found 1 domains
INFO: Found 1 domains in the forest
INFO: Found 3 computers
INFO: Connecting to LDAP server: lab-dc01.lab.justin-p.me
INFO: Found 7 users
INFO: Found 55 groups
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1119
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1120
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1122
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1123
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1124
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1126
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1128
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1136
INFO: Found 0 trusts
INFO: Starting computer enumeration with 10 workers
INFO: Querying computer: LAB-PC02.lab.justin-p.me
INFO: Querying computer: LAB-PC01.lab.justin-p.me
INFO: Querying computer: LAB-DC01.lab.justin-p.me
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1131
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1132
WARNING: Could not resolve SID: S-1-5-21-4293559167-2054256270-1955830364-1133
INFO: Done in 00M 02S

```

computer.json after fix.

```json
{
  "computers": [
    {
      "ObjectIdentifier": "S-1-5-21-4293559167-2054256270-1955830364-1000",
      "AllowedToAct": [],
      "PrimaryGroupSid": "S-1-5-21-4293559167-2054256270-1955830364-516",
      "LocalAdmins": [
        {
          "MemberId": "S-1-5-21-4293559167-2054256270-1955830364-519",
          "MemberType": "Group"
        },
        {
          "MemberId": "S-1-5-21-4293559167-2054256270-1955830364-512",
          "MemberType": "Group"
        },
        {
          "MemberId": "S-1-5-21-4293559167-2054256270-1955830364-500",
          "MemberType": "User"
        },
        {
          "MemberId": "S-1-5-21-4293559167-2054256270-1955830364-1110",
          "MemberType": "User"
        },
        {
          "MemberId": "S-1-5-21-4293559167-2054256270-1955830364-1111",
          "MemberType": "User"
        }
      ],
      "PSRemoteUsers": [],
      "Properties": {
        "name": "LAB-DC01.LAB.JUSTIN-P.ME",

      ...

}

```