### PR TITLE
Increase Timeout and Auto_Range

### DIFF
--- a/bloodhound/ad/authentication.py
+++ b/bloodhound/ad/authentication.py
@@ -60,7 +60,7 @@ class ADAuthentication(object):
         else:
             ldappass = self.password
         ldaplogin = '%s\\%s' % (self.domain, self.username)
-        conn = Connection(server, user=ldaplogin, auto_referrals=False, password=ldappass, authentication=NTLM, receive_timeout=30)
+        conn = Connection(server, user=ldaplogin, auto_referrals=False, password=ldappass, authentication=NTLM, receive_timeout=60, auto_range=True)
 
         # TODO: Kerberos auth for ldap
         if self.kdc is not None:


### PR DESCRIPTION
These two tweaks will help with proxied or slow connections.
1. 60 seconds is just arbitrarily larger and helped in my specific case where proxychains over a slow HTTPS connection was making the results timeout.
2. auto_range allows LDAP3 to pull in more results to Bloodhound.py at one time. This increases the RAM hit, but also decreases timeouts and errors.

I have tested these tweaks in a couple scenarios and they have generally made things go smoother. I don't know if that will be the case for everyone.