### PR TITLE
New feature: ability to adjust the DNS timeouts via CLI

### DIFF
--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -199,6 +199,10 @@ def main():
     parser.add_argument('--dns-tcp',
                         action='store_true',
                         help='Use TCP instead of UDP for DNS queries')
+    parser.add_argument('--dns-timeout',
+                        help='How many seconds to wait before timing out DNS queries (default: 3)',
+                        type=float,
+                        default=3.0)
     parser.add_argument('-d',
                         '--domain',
                         action='store',
@@ -252,7 +256,7 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    ad = AD(auth=auth, domain=args.domain, nameserver=args.nameserver, dns_tcp=args.dns_tcp)
+    ad = AD(auth=auth, domain=args.domain, nameserver=args.nameserver, dns_tcp=args.dns_tcp, dns_timeout=args.dns_timeout)
 
     # Resolve collection methods
     collect = resolve_collection_methods(args.collectionmethod)

--- a/bloodhound/ad/domain.py
+++ b/bloodhound/ad/domain.py
@@ -437,8 +437,8 @@ class AD(object):
         self.dnsresolver.cache = resolver.Cache()
         # Default timeout after 3 seconds if the DNS servers
         # do not come up with an answer
-        self.dnsresolver.lifetime = self.ad.dns_timeout 
-        self.dnsresolver.timeout = self.ad.dns_timeout 
+        self.dnsresolver.lifetime = dns_timeout 
+        self.dnsresolver.timeout = dns_timeout 
         # Also create a custom cache for both forward and backward lookups
         # this cache is thread-safe
         self.dnscache = DNSCache()

--- a/bloodhound/ad/domain.py
+++ b/bloodhound/ad/domain.py
@@ -405,7 +405,7 @@ Active Directory data and cache
 """
 class AD(object):
 
-    def __init__(self, domain=None, auth=None, nameserver=None, dns_tcp=False):
+    def __init__(self, domain=None, auth=None, nameserver=None, dns_tcp=False, dns_timeout=3.0):
         self.domain = domain
         # Object of type ADDomain, added later
         self.domain_object = None
@@ -431,11 +431,14 @@ class AD(object):
             self.dnsresolver.nameservers = [nameserver]
         # Resolve DNS over TCP?
         self.dns_tcp = dns_tcp
+        # Set DNS timeout
+        self.dns_timeout = dns_timeout
         # Give it a cache to prevent duplicate lookups
         self.dnsresolver.cache = resolver.Cache()
         # Default timeout after 3 seconds if the DNS servers
         # do not come up with an answer
-        self.dnsresolver.lifetime = 3.0
+        self.dnsresolver.lifetime = self.ad.dns_timeout 
+        self.dnsresolver.timeout = self.ad.dns_timeout 
         # Also create a custom cache for both forward and backward lookups
         # this cache is thread-safe
         self.dnscache = DNSCache()


### PR DESCRIPTION
While operating in high latency environments, the standard 3 second timeout may not be sufficient, thus the need of higher DNS timeouts may be fulfilled with this PR.