### PR TITLE
Update dockerfile to add rust support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apk update && \
         dbus-dev \
         dbus-glib-dev \
         linux-headers \
+        rust \
+        cargo \
         make && \ 
 	apk add --no-cache bash && \
     pip3 install --upgrade setuptools && \


### PR DESCRIPTION
The docker builds currently fail due to lack of rust and cargo being present inside the container. This PR adds the dependencies to get the container to build again.