### PR TITLE
Added timestamp prefix and zip compression of output files

### DIFF
--- a/bloodhound/enumeration/computers.py
+++ b/bloodhound/enumeration/computers.py
@@ -56,7 +56,7 @@ class ComputerEnumerator(MembershipEnumerator):
         # Store collection methods specified
         self.collect = collect
 
-    def enumerate_computers(self, computers, num_workers=10):
+    def enumerate_computers(self, computers, num_workers=10, timestamp=""):
         """
             Enumerates the computers in the domain. Is threaded, you can specify the number of workers.
             Will spawn threads to resolve computers and enumerate the information.
@@ -64,7 +64,7 @@ class ComputerEnumerator(MembershipEnumerator):
         process_queue = queue.Queue()
 
         result_q = queue.Queue()
-        results_worker = threading.Thread(target=OutputWorker.write_worker, args=(result_q, 'computers.json'))
+        results_worker = threading.Thread(target=OutputWorker.write_worker, args=(result_q, timestamp + 'computers.json'))
         results_worker.daemon = True
         results_worker.start()
         logging.info('Starting computer enumeration with %d workers', num_workers)

--- a/bloodhound/enumeration/domains.py
+++ b/bloodhound/enumeration/domains.py
@@ -43,7 +43,9 @@ class DomainEnumerator(object):
         self.addomain = addomain
         self.addc = addc
 
-    def dump_domain(self, collect, filename='domains.json'):
+    def dump_domain(self, collect, timestamp="", filename='domains.json'):
+
+        filename = timestamp + filename
         """
         Dump trusts. This is currently the only domain info we support, so
         this function handles the entire domain dumping.

--- a/bloodhound/enumeration/memberships.py
+++ b/bloodhound/enumeration/memberships.py
@@ -136,8 +136,8 @@ class MembershipEnumerator(object):
             props['allowedtodelegate'] = ADUtils.get_entry_property(entry, 'msDS-AllowedToDelegateTo', [])
         props['sidhistory'] = [LDAP_SID(bsid).formatCanonical() for bsid in ADUtils.get_entry_property(entry, 'sIDHistory', [])]
 
-    def enumerate_users(self):
-        filename = 'users.json'
+    def enumerate_users(self, timestamp=""):
+        filename = timestamp + 'users.json'
 
         # Should we include extra properties in the query?
         with_properties = 'objectprops' in self.collect
@@ -232,7 +232,7 @@ class MembershipEnumerator(object):
 
         logging.debug('Finished writing users')
 
-    def enumerate_groups(self):
+    def enumerate_groups(self, timestamp=""):
 
         highvalue = ["S-1-5-32-544", "S-1-5-32-550", "S-1-5-32-549", "S-1-5-32-551", "S-1-5-32-548"]
 
@@ -247,7 +247,7 @@ class MembershipEnumerator(object):
         with_properties = 'objectprops' in self.collect
         acl = 'acl' in self.collect
 
-        filename = 'groups.json'
+        filename = timestamp + 'groups.json'
         entries = self.addc.get_groups(include_properties=with_properties, acl=acl)
 
         logging.debug('Writing groups to file: %s', filename)
@@ -323,12 +323,12 @@ class MembershipEnumerator(object):
 
         logging.debug('Finished writing groups')
 
-    def enumerate_computers_dconly(self):
+    def enumerate_computers_dconly(self,timestamp =""):
         '''
         Enumerate computer objects. This function is only used if no
         collection was requested that required connecting to computers anyway.
         '''
-        filename = 'computers.json'
+        filename = timestamp + 'computers.json'
 
         acl = 'acl' in self.collect
         entries = self.addc.ad.computers.values()
@@ -481,14 +481,14 @@ class MembershipEnumerator(object):
         self.result_q.put(augroup)
 
 
-    def enumerate_memberships(self):
+    def enumerate_memberships(self, timestamp=""):
         """
         Run appropriate enumeration tasks
         """
-        self.enumerate_users()
-        self.enumerate_groups()
+        self.enumerate_users(timestamp)
+        self.enumerate_groups(timestamp)
         if not ('localadmin' in self.collect
                 or 'session' in self.collect
                 or 'loggedon' in self.collect
                 or 'experimental' in self.collect):
-            self.enumerate_computers_dconly()
+            self.enumerate_computers_dconly(timestamp)

--- a/bloodhound/enumeration/outputworker.py
+++ b/bloodhound/enumeration/outputworker.py
@@ -27,12 +27,15 @@ import traceback
 import codecs
 import json
 
+
 class OutputWorker(object):
     @staticmethod
     def write_worker(result_q, computers_filename):
         """
             Worker to write the results from the results_q to the given files.
         """
+
+      
         computers_out = codecs.open(computers_filename, 'w', 'utf-8')
 
         # If the logging level is DEBUG, we ident the objects


### PR DESCRIPTION
Compression of output files as an toggle
```
python3 bloodhound.py -c All -d legitcorp.net -dc 'DC01.legitcorp.net' -u Administrator -p 'Passw0rd!123' -ns 192.168.58.111 --zip 
INFO: Found AD domain: legitcorp.net
INFO: Connecting to LDAP server: DC01.legitcorp.net
INFO: Found 1 domains
INFO: Found 1 domains in the forest
INFO: Found 5 computers
INFO: Connecting to LDAP server: DC01.legitcorp.net
INFO: Found 130 users
INFO: Found 75 groups
INFO: Found 0 trusts
INFO: Starting computer enumeration with 10 workers
INFO: Querying computer: WIN10-jIGYB.legitcorp.net
INFO: Querying computer: WIN7DEV-PC.legitcorp.net
INFO: Querying computer: legitcorp.net
INFO: Querying computer: DC01.legitcorp.net
INFO: Ignoring host legitcorp.net since its hostname does not match: Supplied hostname legitcorp.net does not match reported hostnames dc01 or dc01.legitcorp.net
INFO: Skipping enumeration for WIN10-jIGYB.legitcorp.net since it could not be resolved.
INFO: Done in 00M 02S
INFO: Compressing output into 20210406113953_bloodhound.zip

```

timestamps by default 
 ```
$ python3 bloodhound.py -c All -d legitcorp.net -dc 'DC01.legitcorp.net' -u Administrator -p 'Passw0rd!123' -ns 192.168.58.111 
INFO: Found AD domain: legitcorp.net
INFO: Connecting to LDAP server: DC01.legitcorp.net
INFO: Found 1 domains
INFO: Found 1 domains in the forest
INFO: Found 5 computers
INFO: Connecting to LDAP server: DC01.legitcorp.net
INFO: Found 130 users
INFO: Found 75 groups
INFO: Found 0 trusts
INFO: Starting computer enumeration with 10 workers
INFO: Querying computer: WIN10-jIGYB.legitcorp.net
INFO: Querying computer: WIN7DEV-PC.legitcorp.net
INFO: Querying computer: legitcorp.net
INFO: Querying computer: DC01.legitcorp.net
INFO: Ignoring host legitcorp.net since its hostname does not match: Supplied hostname legitcorp.net does not match reported hostnames dc01 or dc01.legitcorp.net
INFO: Skipping enumeration for WIN10-jIGYB.legitcorp.net since it could not be resolved.
INFO: Done in 00M 02S
                                                                                                                                                                                                                      
$ ls  | grep -i ".json"                                                                                                        
20210406114056_computers.json
20210406114056_domains.json
20210406114056_groups.json
20210406114056_users.json
```