### PR TITLE
Fix hyphen typo in gMSA reading functionality.

### DIFF
--- a/bloodhound/ad/domain.py
+++ b/bloodhound/ad/domain.py
@@ -317,7 +317,7 @@ class ADDC(ADComputer):
 
         properties = ['sAMAccountName', 'distinguishedName', 'sAMAccountType',
                       'objectSid', 'primaryGroupID']
-        if 'msDS-GroupMSAMembership'.lower() in self.objecttype_guid_map:
+        if 'ms-DS-GroupMSAMembership'.lower() in self.objecttype_guid_map:
             properties.append('msDS-GroupMSAMembership')
         if include_properties:
             properties += ['servicePrincipalName', 'userAccountControl', 'displayName',


### PR DESCRIPTION
self.objecttype_guid_map has a hyphen while the comparison did not and this was causing it to not include the msDS-GroupMSAMembership attribute. 
Because of this https://github.com/fox-it/BloodHound.py/blob/master/bloodhound/enumeration/memberships.py#L205 was failing even when it shouldn't.