### PR TITLE
Kerberos Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This version of BloodHound.py is **only compatible with BloodHound 3.0 or newer*
 ## Limitations
 BloodHound.py currently has the following limitations:
 - Supports most, but not all BloodHound (SharpHound) features (see below for supported collection methods, mainly GPO based methods are missing)
-- Kerberos authentication support is not yet complete
 
 ## Installation and usage
 You can install the ingestor via pip with `pip install bloodhound`, or by cloning this repository and running `python setup.py install`, or with `pip install .`.

--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -189,7 +189,7 @@ def main():
     parser.add_argument('-k',
                         '--kerberos',
                         action='store_true',
-                        help='Use kerberos')
+                        help='Use kerberos (not fully compatible with with custom nameserver, kerberos stack uses system DNS)')
     parser.add_argument('--hashes',
                         action='store',
                         help='LM:NLTM hashes')

--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -246,7 +246,8 @@ def main():
     if args.kerberos is True:
         logging.debug('Authentication: kerberos')
         kerberize()
-        auth = ADAuthentication()
+        # The username is optional for kerberos but may be requird to specify the client principal
+        auth = ADAuthentication(username=args.username, domain=args.domain) 
     elif args.username is not None and args.password is not None:
         logging.debug('Authentication: username/password')
         auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain)


### PR DESCRIPTION
During my OSEP lab I stepped into the problem that there is a Kerberos switch but no functionality implemented (see  #75 ). 
I implemented support for both LDAP and SMB. In this case it is not possible to bypass the system DNS because of the kerberos libraries. 
The changes were tested with a pretty simple Server 2016 AD.