### PR TITLE
Fix typo: manualy -> manually

### DIFF
--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -47,7 +47,7 @@ class BloodHound(object):
             sys.exit(1)
 
         if not self.ad.baseDN:
-            logging.error('Could not figure out the domain to query. Please specify this manualy with -d')
+            logging.error('Could not figure out the domain to query. Please specify this manually with -d')
             sys.exit(1)
 
         pdc = self.ad.dcs()[0]

--- a/createforestcache.py
+++ b/createforestcache.py
@@ -47,7 +47,7 @@ class BloodHound(object):
             sys.exit(1)
 
         if not self.ad.baseDN:
-            logging.error('Could not figure out the domain to query. Please specify this manualy with -d')
+            logging.error('Could not figure out the domain to query. Please specify this manually with -d')
             sys.exit(1)
 
         pdc = self.ad.dcs()[0]


### PR DESCRIPTION
Whilst watching a video from John Hammond about BloodHound he stumbled upon this typo in an error message produced by BloodHound.py. The typo is in the following sentence:

> ERROR: Could not figure out the domain to query. Please specify this manualy with -d

Manually here should be written with two Ls, rather than one.

Timestamp where typo can be seen:

> https://youtu.be/yp8fw72oQvY?t=1415