### PR TITLE
Fix issues with the --disable-autogc parameter 

### DIFF
--- a/bloodhound/ad/authentication.py
+++ b/bloodhound/ad/authentication.py
@@ -25,6 +25,7 @@
 import logging
 from ldap3 import Server, Connection, NTLM, ALL
 from ldap3.core.results import RESULT_STRONGER_AUTH_REQUIRED
+from ldap3.core.exceptions import LDAPSocketOpenError
 
 """
 Active Directory authentication helper
@@ -74,14 +75,25 @@ class ADAuthentication(object):
             #     logging.warning('Kerberos login failed: %s' % e)
             #     return None
         else:
-            logging.debug('Authenticating to LDAP server')
-            if not conn.bind():
-                result = conn.result
-                if result['result'] == RESULT_STRONGER_AUTH_REQUIRED and protocol == 'ldap':
-                    logging.warning('LDAP Authentication is refused because LDAP signing is enabled. '
-                                    'Trying to connect over LDAPS instead...')
-                    return self.getLDAPConnection(hostname, baseDN, 'ldaps')
+            try:
+                logging.debug('Authenticating to LDAP server')
+                if not conn.bind():
+                    result = conn.result
+                    if result['result'] == RESULT_STRONGER_AUTH_REQUIRED and protocol == 'ldap':
+                        logging.warning('LDAP Authentication is refused because LDAP signing is enabled. '
+                                        'Trying to connect over LDAPS instead...')
+                        return self.getLDAPConnection(hostname, baseDN, 'ldaps')
+                    else:
+                        logging.error('Failure to authenticate with LDAP! Error %s' % result['message'])
+                        return None
+            except LDAPSocketOpenError:
+                if gc:
+                    logging.error('Could not connect to the global catalog server\n'
+                                  'Either specify a hostname with -gc or disable gc resolution with --disable-autogc')
                 else:
-                    logging.error('Failure to authenticate with LDAP! Error %s' % result['message'])
-                    return None
+                    logging.error('Could not connect to the ldap server\n'
+                                  'Specify a hostname with -dc')
+
+                return None
+
         return conn

--- a/bloodhound/ad/domain.py
+++ b/bloodhound/ad/domain.py
@@ -606,23 +606,24 @@ class AD(object):
         except resolver.NXDOMAIN:
             pass
 
-        try:
-            q = self.dnsresolver.query(query.replace('pdc','gc'), 'SRV', tcp=self.dns_tcp)
-            for r in q:
-                gc = str(r.target).rstrip('.')
-                logging.debug('Found Global Catalog server: %s' % gc)
-                if gc not in self._gcs:
-                    self._gcs.append(gc)
+        if options and not options.disable_autogc:
+            try:
+                q = self.dnsresolver.query(query.replace('pdc','gc'), 'SRV', tcp=self.dns_tcp)
+                for r in q:
+                    gc = str(r.target).rstrip('.')
+                    logging.debug('Found Global Catalog server: %s' % gc)
+                    if gc not in self._gcs:
+                        self._gcs.append(gc)
 
-        except resolver.NXDOMAIN:
-            # Only show warning if we don't already have a GC specified manually
-            if options and not options.global_catalog:
-                if not options.disable_autogc:
-                    logging.warning('Could not find a global catalog server, assuming the primary DC has this role\n'
-                                    'If this gives errors, either specify a hostname with -gc or disable gc resolution with --disable-autogc')
-                    self._gcs = self._dcs
-                else:
-                    logging.warning('Could not find a global catalog server. Please specify one with -gc')
+            except resolver.NXDOMAIN:
+                # Only show warning if we don't already have a GC specified manually
+                if options and not options.global_catalog:
+                    if not options.disable_autogc:
+                        logging.warning('Could not find a global catalog server, assuming the primary DC has this role\n'
+                                        'If this gives errors, either specify a hostname with -gc or disable gc resolution with --disable-autogc')
+                        self._gcs = self._dcs
+                    else:
+                        logging.warning('Could not find a global catalog server. Please specify one with -gc')
 
         if kerberos is True:
             try:


### PR DESCRIPTION
Hi,

Recently,  had an issue where bloodhound-python would hang because of a crash while trying to connect to the global catalog (which was not reachable due to a firewall). While Investigating the issue, I noticed that the --disable-autogc was not implemented at all. This commit should fix that and some related error handling when a DC/GC is not reachble.