### PR TITLE
Handle properly missing linked GPO

### DIFF
--- a/bloodhound/enumeration/domains.py
+++ b/bloodhound/enumeration/domains.py
@@ -159,7 +159,7 @@ class DomainEnumerator(object):
                 try:
                     link['GUID'] = self.addomain.get_dn_from_cache_or_ldap(gplink_dn.upper())['ObjectIdentifier']
                     domain['Links'].append(link)
-                except KeyError:
+                except TypeError:
                     logging.warning('Could not resolve GPO link to {0}'.format(gplink_dn))
 
         # Single domain only

--- a/bloodhound/enumeration/memberships.py
+++ b/bloodhound/enumeration/memberships.py
@@ -539,7 +539,7 @@ class MembershipEnumerator(object):
                 try:
                     link['GUID'] = self.get_membership(gplink_dn.upper())['ObjectIdentifier']
                     ou['Links'].append(link)
-                except KeyError:
+                except TypeError:
                     logging.warning('Could not resolve GPO link to {0}'.format(gplink_dn))
             
             # Create cache entry for links


### PR DESCRIPTION
When the collector tries to resolve the dn of linked GPOs, there is an uncatched error when a GPO does not exist (anymore).

`get_dn_from_cache_or_ldap` returns `None` if the dn can not be found (`ad/domains.py` line 709), and `None["ObjectIdentifier"]` raises a `TypeError` (and not a `KeyError`). 

Example:
```
>>> None["toto"]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'NoneType' object is not subscriptable
```

