### PR TITLE
Fix session enumeration caching

### DIFF
--- a/bloodhound/enumeration/computers.py
+++ b/bloodhound/enumeration/computers.py
@@ -161,16 +161,16 @@ class ComputerEnumerator(MembershipEnumerator):
                     # For every session, resolve the SAM name in the GC if needed
                     domain = self.addomain.domain
                     try:
-                        users = self.addomain.samcache.get(samname)
+                        users = self.addomain.samcache.get(ses['user'])
                     except KeyError:
                         # Look up the SAM name in the GC
                         entries = self.addomain.objectresolver.resolve_samname(ses['user'], use_gc=use_gc)
                         if entries is not None:
                             users = [user['attributes']['objectSid'] for user in entries]
                         if entries is None or users == []:
-                            logging.warning('Failed to resolve SAM name %s in current forest', samname)
+                            logging.warning('Failed to resolve SAM name %s in current forest', ses['user'])
                             continue
-                        self.addomain.samcache.put(samname, users)
+                        self.addomain.samcache.put(ses['user'], users)
 
                     # Resolve the IP to obtain the host the session is from
                     try:


### PR DESCRIPTION
I think there is a mistake in session enumeration.

If a computer hosts multiple net sessions, only one distinct user is reported in `computers.json`. This is due to an error in the key used to cache `sAMAccountName -> objectSid` resolutions.

Currently, the key is `samcache` which contains the `sAMAccountName` of the computer, so it is the same for every sessions.

https://github.com/fox-it/BloodHound.py/blob/21d3414ecaec3eb8e8f57553f296bfe0c7cf61be/bloodhound/enumeration/computers.py#L93

The first session user SID is resolved and cached with `samname` key. Every subsequent session will then use the cached SID instead of resolving and caching the SID of their own user.

The key should instead be the `sAMAccountName` of the session user, which is `ses['user']`.