### PR TITLE
Fix INHERIT_ONLY_ACE false positive when AceType == 0 

### DIFF
--- a/bloodhound/enumeration/acls.py
+++ b/bloodhound/enumeration/acls.py
@@ -189,6 +189,10 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
             is_inherited = ace_object.has_flag(ACE.INHERITED_ACE)
             mask = ace_object.acedata.mask
             # ACCESS_ALLOWED_ACE
+            if not ace_object.has_flag(ACE.INHERITED_ACE) and ace_object.has_flag(ACE.INHERIT_ONLY_ACE):
+                # ACE is set on this object, but only inherited, so not applicable to us
+                continue
+            
             if mask.has_priv(ACCESS_MASK.GENERIC_ALL):
                 # Generic all includes all other rights, so skip from here
                 relations.append(build_relation(sid, 'GenericAll', inherited=is_inherited))


### PR DESCRIPTION
An ACE that applies only to descendant objects will also be reported as applying to the object where it is located. This is due to the missing INHERIT_ONLY_ACE condition when the AceType is 0. 

**Steps to Reproduce**
* Select a principal and an object where the principal has no privileges on it, such as an OU.
* On the OU, add an ACE for the principal with privileges GENERIC_ALL that applies only to descendant objects.
* Collect the data and import it into BloodHound.
* Query for relationships between the principal and the OU. The principal will be shown as having GenericAll over the OU when in reality it only applies to descendant objects.