### PR TITLE
Fix AES authentication

### DIFF
--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -267,23 +267,19 @@ def main():
     if args.username is not None and args.password is not None:
         logging.debug('Authentication: username/password')
         auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method)
-    elif args.username is not None and args.password is None and args.hashes is None:
+    elif args.username is not None and args.password is None and args.hashes is None and args.no_pass is None:
         args.password = getpass.getpass()
         auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method)
     elif args.username is None and (args.password is not None or args.hashes is not None):
         logging.error('Authentication: password or hashes provided without username')
         sys.exit(1)
-    elif (args.hashes is not None or args.aesKey is not None) and args.username is not None:
-        if args.hashes:
-            logging.debug('Authentication: NT hash')
-            lm, nt = args.hashes.split(":")
-            auth = ADAuthentication(lm_hash=lm, nt_hash=nt, username=args.username, domain=args.domain, auth_method=args.auth_method)
-            if args.aesKey:
-                logging.debug('Authentication: Kerberos AES')
-                auth.set_aeskey(args.aesKey)
-        else:
-            logging.debug('Authentication: Kerberos AES')
-            auth = ADAuthentication(username=args.username, domain=args.domain, aeskey=args.aesKey, auth_method=args.auth_method)
+    elif args.hashes is not None and args.username is not None:
+        logging.debug('Authentication: NT hash')
+        lm, nt = args.hashes.split(":")
+        auth = ADAuthentication(lm_hash=lm, nt_hash=nt, username=args.username, domain=args.domain, auth_method=args.auth_method)
+    elif args.aesKey is not None and args.username is not None:
+        logging.debug('Authentication: Kerberos AES')
+        auth = ADAuthentication(username=args.username, domain=args.domain, aeskey=args.aesKey, auth_method=args.auth_method)
     else:
         if not args.kerberos:
             parser.print_help()


### PR DESCRIPTION
Hello

I've faced an error while using AES key authentication. This fix is working for me, please let me know if it works for you as well.

Thanks!

Output before fix:
```
└─$ /home/kali/.local/bin/bloodhound-python -d essos.local -u daenerys.targaryen@essos.local -aesKey cf091fbd07f729567ac448ba96c08b12fa67c1372f439ae093f67c6e2cf82378 --auth-method kerberos -v -c all,LoggedOn -ns 192.168.56.12 
Password: 
DEBUG: Resolved collection methods: dcom, rdp, trusts, acl, localadmin, session, container, psremote, group, loggedon, objectprops
DEBUG: Using DNS to retrieve domain information
DEBUG: Querying domain controller information from DNS
DEBUG: Using domain hint: essos.local
INFO: Found AD domain: essos.local
DEBUG: Found primary DC: meereen.essos.local
DEBUG: Found Global Catalog server: meereen.essos.local
DEBUG: Found KDC for enumeration domain: meereen.essos.local
INFO: Getting TGT for user
DEBUG: Trying to connect to KDC at essos.local
DEBUG: Trying to connect to KDC at essos.local
DEBUG: Server time (UTC): 2023-07-02 20:56:00
DEBUG: Traceback (most recent call last):
  File "/home/kali/.local/pipx/venvs/bloodhound/lib/python3.11/site-packages/bloodhound/ad/authentication.py", line 191, in get_tgt
    tgt, cipher, _, session_key = getKerberosTGT(username, self.password, self.userdomain,
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/.local/pipx/venvs/bloodhound/lib/python3.11/site-packages/impacket/krb5/kerberosv5.py", line 312, in getKerberosTGT
    tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/.local/pipx/venvs/bloodhound/lib/python3.11/site-packages/impacket/krb5/kerberosv5.py", line 91, in sendReceive
    raise krbError
impacket.krb5.kerberosv5.KerberosError: Kerberos SessionError: KDC_ERR_PREAUTH_FAILED(Pre-authentication information was invalid)

ERROR: Failed to get Kerberos TGT.
Traceback (most recent call last):
  File "/home/kali/.local/bin/bloodhound-python", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/kali/.local/pipx/venvs/bloodhound/lib/python3.11/site-packages/bloodhound/__init__.py", line 332, in main
    auth.get_tgt()
  File "/home/kali/.local/pipx/venvs/bloodhound/lib/python3.11/site-packages/bloodhound/ad/authentication.py", line 191, in get_tgt
    tgt, cipher, _, session_key = getKerberosTGT(username, self.password, self.userdomain,
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/.local/pipx/venvs/bloodhound/lib/python3.11/site-packages/impacket/krb5/kerberosv5.py", line 312, in getKerberosTGT
    tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/.local/pipx/venvs/bloodhound/lib/python3.11/site-packages/impacket/krb5/kerberosv5.py", line 91, in sendReceive
    raise krbError
impacket.krb5.kerberosv5.KerberosError: Kerberos SessionError: KDC_ERR_PREAUTH_FAILED(Pre-authentication information was invalid)
```

Output after fix:
```
└─$ /home/kali/.local/bin/bloodhound-python -d essos.local -u daenerys.targaryen@essos.local -aesKey cf091fbd07f729567ac448ba96c08b12fa67c1372f439ae093f67c6e2cf82378 --auth-method kerberos -v -c all,LoggedOn -ns 192.168.56.12   
DEBUG: Authentication: Kerberos AES
DEBUG: Resolved collection methods: acl, rdp, loggedon, localadmin, objectprops, container, session, trusts, dcom, psremote, group
DEBUG: Using DNS to retrieve domain information
DEBUG: Querying domain controller information from DNS
DEBUG: Using domain hint: essos.local
INFO: Found AD domain: essos.local
DEBUG: Found primary DC: meereen.essos.local
DEBUG: Found Global Catalog server: meereen.essos.local
DEBUG: Found KDC for enumeration domain: meereen.essos.local
INFO: Getting TGT for user
DEBUG: Trying to connect to KDC at essos.local
DEBUG: Trying to connect to KDC at essos.local
DEBUG: Using LDAP server: meereen.essos.local
DEBUG: Using base DN: DC=essos,DC=local
DEBUG: Using kerberos KDC: meereen.essos.local
DEBUG: Using kerberos realm: ESSOS.LOCAL
INFO: Connecting to LDAP server: meereen.essos.local
DEBUG: Authenticating to LDAP server with Kerberos
DEBUG: Trying to connect to KDC at meereen.essos.local
DEBUG: Found LAPS attributes in schema
DEBUG: Found KeyCredentialLink attributes in schema
INFO: Found 1 domains
INFO: Found 1 domains in the forest
INFO: Found 2 computers
DEBUG: Writing users to file: 20230702225338_users.json
INFO: Connecting to LDAP server: meereen.essos.local
DEBUG: Authenticating to LDAP server with Kerberos
DEBUG: Trying to connect to KDC at meereen.essos.local
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-512
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-526
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-527
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-519
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-1117
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-1119
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-1120
INFO: Found 11 users
DEBUG: Finished writing users
DEBUG: Writing groups to file: 20230702225338_groups.json
DEBUG: Querying resolver LDAP for DN CN=S-1-5-21-951309812-1969785940-3495862469-1116,CN=ForeignSecurityPrincipals,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=S-1-5-21-951309812-1969785940-3495862469-1124,CN=ForeignSecurityPrincipals,DC=essos,DC=local
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-1008
DEBUG: Querying resolver LDAP for DN CN=Group Policy Creator Owners,CN=Users,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=Domain Admins,CN=Users,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=Cert Publishers,CN=Users,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=Enterprise Admins,CN=Users,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=Schema Admins,CN=Users,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=Domain Controllers,CN=Users,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=S-1-5-9,CN=ForeignSecurityPrincipals,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=S-1-5-11,CN=ForeignSecurityPrincipals,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=S-1-5-17,CN=ForeignSecurityPrincipals,DC=essos,DC=local
DEBUG: Querying resolver LDAP for DN CN=S-1-5-4,CN=ForeignSecurityPrincipals,DC=essos,DC=local
INFO: Found 57 groups
DEBUG: Finished writing groups
DEBUG: Writing GPOs to file: 20230702225338_gpos.json
INFO: Found 3 gpos
DEBUG: Finished writing GPO
DEBUG: Writing OU to file: 20230702225338_ous.json
DEBUG: Don't care about acetype 1
INFO: Found 2 ous
DEBUG: Finished writing OU
DEBUG: Writing containers to file: 20230702225338_containers.json
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-1110
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-553
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-516
INFO: Found 22 containers
DEBUG: Finished writing containers
DEBUG: Opening file for writing: 20230702225338_domains.json
DEBUG: Don't care about acetype 1
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-498
INFO: Found 1 trusts
DEBUG: Finished writing domain info
INFO: Starting computer enumeration with 10 workers
DEBUG: Start working
DEBUG: Start working
DEBUG: Start working
DEBUG: Start working
DEBUG: Start working
DEBUG: Start working
DEBUG: Start working
DEBUG: Start working
DEBUG: Start working
DEBUG: Start working
INFO: Querying computer: braavos.essos.local
DEBUG: Querying computer: braavos.essos.local
INFO: Querying computer: meereen.essos.local
DEBUG: Querying computer: meereen.essos.local
DEBUG: Resolved: 192.168.56.12
DEBUG: Trying connecting to computer: meereen.essos.local
DEBUG: Resolved: 192.168.56.23
DEBUG: Trying connecting to computer: braavos.essos.local
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\PIPE\srvsvc]
DEBUG: Trying to connect to KDC at meereen.essos.local
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.23[\PIPE\srvsvc]
DEBUG: Trying to connect to KDC at meereen.essos.local
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\PIPE\samr]
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.23[\PIPE\samr]
DEBUG: Opening domain handle
DEBUG: Opening domain handle
DEBUG: Found 544 SID: S-1-5-21-1890677768-3030231249-2436160466-500
DEBUG: Found 544 SID: S-1-5-21-1890677768-3030231249-2436160466-1008
DEBUG: Found 544 SID: S-1-5-21-1890677768-3030231249-2436160466-519
DEBUG: Found 544 SID: S-1-5-21-1890677768-3030231249-2436160466-512
DEBUG: Found 544 SID: S-1-5-21-1890677768-3030231249-2436160466-1118
DEBUG: Found 544 SID: S-1-5-21-1776520453-4046468180-1408721143-500
DEBUG: Ignoring local group S-1-5-21-1776520453-4046468180-1408721143-500
DEBUG: Found 544 SID: S-1-5-21-1776520453-4046468180-1408721143-1012
DEBUG: Ignoring local group S-1-5-21-1776520453-4046468180-1408721143-1012
DEBUG: Found 544 SID: S-1-5-21-1890677768-3030231249-2436160466-512
DEBUG: Found 544 SID: S-1-5-21-1890677768-3030231249-2436160466-1120
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\PIPE\lsarpc]
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.23[\PIPE\lsarpc]
DEBUG: Resolved SID to name: ADMINISTRATOR@ESSOS.LOCAL
DEBUG: Resolved SID to name: DOMAIN ADMINS@ESSOS.LOCAL
DEBUG: Resolved SID to name: SNAPLABS@ESSOS.LOCAL
DEBUG: Resolved SID to name: KHAL.DROGO@ESSOS.LOCAL
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.23[\PIPE\samr]
DEBUG: Resolved SID to name: ENTERPRISE ADMINS@ESSOS.LOCAL
DEBUG: Resolved SID to name: DOMAIN ADMINS@ESSOS.LOCAL
DEBUG: Resolved SID to name: DAENERYS.TARGARYEN@ESSOS.LOCAL
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\PIPE\samr]
DEBUG: Opening domain handle
DEBUG: Opening domain handle
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.23[\PIPE\samr]
DEBUG: Found 555 SID: S-1-5-21-1890677768-3030231249-2436160466-1114
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\PIPE\lsarpc]
DEBUG: Opening domain handle
DEBUG: Resolved SID to name: TARGARYEN@ESSOS.LOCAL
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\PIPE\samr]
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.23[\PIPE\samr]
DEBUG: Opening domain handle
DEBUG: Opening domain handle
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\PIPE\samr]
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.23[\PIPE\wkssvc]
DEBUG: Found logged on user at braavos.essos.local: sql_svc@essos.local
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.23[\pipe\winreg]
DEBUG: Opening domain handle
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\PIPE\wkssvc]
INFO: User with SID S-1-5-21-1890677768-3030231249-2436160466-1122 is logged in on braavos.essos.local
DEBUG: DCE/RPC binding: ncacn_np:192.168.56.12[\pipe\winreg]
DEBUG: Querying LDAP for SAM Name sql_svc
DEBUG: Querying resolver LDAP for SID S-1-5-21-1890677768-3030231249-2436160466-1121
DEBUG: Write worker obtained a None value, exiting
DEBUG: Write worker is done, closing files
INFO: Done in 00M 22S
```