### PR TITLE
Bugfixes: IPv6 connection to ldap, support for multiple addresses

### DIFF
--- a/bloodhound/ad/domain.py
+++ b/bloodhound/ad/domain.py
@@ -518,7 +518,7 @@ class ADDC(ADComputer):
         if include_properties:
             properties += ['servicePrincipalName', 'msDS-AllowedToDelegateTo', 'sIDHistory', 'whencreated',
                            'lastLogon', 'lastLogonTimestamp', 'pwdLastSet', 'operatingSystem', 'description',
-                           'operatingSystemServicePack']
+                           'operatingSystemServicePack', 'operatingSystemVersion']
             # Difference between guid map which maps the lowercase schema object name and the property name itself
             if 'ms-DS-Allowed-To-Act-On-Behalf-Of-Other-Identity'.lower() in self.objecttype_guid_map:
                 properties.append('msDS-AllowedToActOnBehalfOfOtherIdentity')


### PR DESCRIPTION
Fixes #227 - supports IPv6 connection to LDAP server.
Incorporates @scmanjarrez fix for #217 to account for multiple addresses being returned (will always be the case in a dual stack environment etc).
