### PR TITLE
Correct GUID mapping for the `WriteGPLink` edge

### DIFF
--- a/bloodhound/enumeration/acls.py
+++ b/bloodhound/enumeration/acls.py
@@ -38,7 +38,7 @@ EXTRIGHTS_GUID_MAPPING = {
     "UserForceChangePassword": string_to_bin("00299570-246d-11d0-a768-00aa006e0529"),
     "AllowedToAct": string_to_bin("3f78c3e5-f79a-46bd-a0b8-9d18116ddc79"),
     "UserAccountRestrictionsSet": string_to_bin("4c164200-20c0-11d0-a768-00aa006e0529"),
-    "WriteGPLink": string_to_bin("f30e3bbf-9ff0-11d1-b603-0000f80367c1")
+    "WriteGPLink": string_to_bin("f30e3bbe-9ff0-11d1-b603-0000f80367c1")
 }
 
 def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):


### PR DESCRIPTION
Hey @dirkjanm,

I noticed a small error in the GUID mapping for the `WriteGPLink` edge. The GUID is actually associated with [GP-Options](https://learn.microsoft.com/fr-fr/windows/win32/adschema/a-gpoptions), not [GP-Link](https://learn.microsoft.com/fr-fr/windows/win32/adschema/a-gplink).

This PR corrects the mapping by replacing it with the proper GUID for GP-Link. For reference, this is the same GUID used in [SharpHoundCommon](https://github.com/SpecterOps/SharpHoundCommon/blob/68a68c6eab5375b46f975274b16ff1acdc35dc48/src/CommonLib/Processors/ACEGuids.cs#L15).